### PR TITLE
Modified the serverType function to support Red hat kvm platform

### DIFF
--- a/sure.py
+++ b/sure.py
@@ -388,7 +388,7 @@ def  dpiStatus(dpi_stats):
 #Server type: onprem/cloud
 def serverType():
 	server_type = str(executeCommand('cat /sys/devices/virtual/dmi/id/sys_vendor'))
-	if 'VMware' in server_type:
+	if 'VMware' in server_type or 'Red Hat' in server_type:   #add red hat kvm type
 		return 'on-prem'
 	elif 'Amazon'in server_type or 'Microsoft' in server_type:
 		return 'on-cloud'


### PR DESCRIPTION
I run into unbounded error when run sure.py on kvm platform.
Check the sys_vendor and get "Red hat", Add Red hat in server_type and return the correct check result.
Test the modified script in the production environment.