### PR TITLE
v3.2

### DIFF
--- a/python2/py2_sure.py
+++ b/python2/py2_sure.py
@@ -1601,12 +1601,12 @@ def criticalChecktwentytwo(version):
 
 #17:Check:Controllers:Verify if stale entry of vManage+vSmart UUID present on any one cEdge
 def criticalChecktwentythree(cedge_validvsmarts_info, controllers_info, cedge_ip):
+	api_sn = None
+	controllers_info_sn = None
 	if cedge_ip == None:
 		check_result = 'SUCCESSFUL'
 		check_analysis = 'There are no cEdge devices connected hence this check is not required.'
 		check_action = None
-		api_sn = None
-		controllers_info_sn = None
 	else:   
 		api_sn = [item["serial-number"] for item in cedge_validvsmarts_info['data']]
 		controllers_info_sn = [item[6] for item in controllers_info.values() if item[3] == "reachable" and item[0] in ['vmanage', 'vsmart']]

--- a/python3/py3_sure.py
+++ b/python3/py3_sure.py
@@ -1537,6 +1537,8 @@ def criticalChecktwentytwo(version):
 
 #17:Check:Controllers:Verify if stale entry of vManage+vSmart UUID present on any one cEdge
 def criticalChecktwentythree(cedge_validvsmarts_info, controllers_info, cedge_ip):
+	api_sn = None
+	controllers_info_sn = None
 	if cedge_ip == None:
 		check_result = 'SUCCESSFUL'
 		check_analysis = 'There are no cEdge devices connected hence this check is not required.'


### PR DESCRIPTION
Resolved Issue reported by Afroz

INFO:#17:Check::Controllers:Verify if stale entry of vManage+vSmart UUID present on any one cEdge
ERROR:local variable 'api_sn' referenced before assignment
Traceback (most recent call last):
  File "py3_sure.py", line 2703, in <module>
    api_sn, controllers_info_sn, check_result, check_analysis, check_action = criticalChecktwentythree(cedge_validvsmarts_info, controllers_info, cedge_ip)
  File "py3_sure.py", line 1556, in criticalChecktwentythree
    return api_sn, controllers_info_sn, check_result, check_analysis, check_action
UnboundLocalError: local variable 'api_sn' referenced before assignment