### PR TITLE
Add absolute path to executables

### DIFF
--- a/python3/py3_sure.py
+++ b/python3/py3_sure.py
@@ -103,7 +103,7 @@ def argValidation(args):
 def showCommand(exec_mode_command):
 	exec_mode_command = exec_mode_command+'\n'
 	exec_mode_command = exec_mode_command.encode()
-	p = subprocess.Popen('viptela_cli'.format(args.username), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	p = subprocess.Popen('/usr/sbin/viptela_cli'.format(args.username), shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 	p.stdin.write(exec_mode_command) #passing command
 	stdOutput,stdError = p.communicate()
 	p.stdin.close()
@@ -1611,11 +1611,11 @@ def criticalChecktwentythree(cedge_validvsmarts_info, controllers_info, cedge_ip
 
 #02:Check:vManage:Network Card type
 def warningChecktwo():
-	eth_data = executeCommand("ifconfig | grep '^eth[0-9]'")
+	eth_data = executeCommand("/sbin/ifconfig | grep '^eth[0-9]'")
 	eth_drivers = {}
 	eth_data = [e for e in eth_data.split() if 'eth' in e]
 	for eth in eth_data:
-		driver = executeCommand('ethtool -i {} | grep driver'.format(eth))
+		driver = executeCommand('/usr/sbin/ethtool -i {} | grep driver'.format(eth))
 		if 'e1000' in driver.split()[1]:
 			eth_drivers[eth] = driver.split()[1]
 


### PR DESCRIPTION
Utilize the absolute path to access `viptela_cli`, `ifconfig` and `ethtool`

Resolving https://github.com/CiscoDevNet/sure/issues/127